### PR TITLE
Fix icon formatter property access

### DIFF
--- a/src/Plugin/Field/FieldFormatter/FontAwesomeIconFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/FontAwesomeIconFormatter.php
@@ -25,7 +25,7 @@ class FontAwesomeIconFormatter extends FormatterBase {
     $elements = [];
 
     foreach ($items as $delta => $item) {
-      $icon = isset($item->getValue('values')['value']) ? $item->getValue('values')['value'] : '';
+      $icon = $item->get('value')->getValue();
       $elements[$delta] = [
         '#theme' => 'fontawesome_icon_formatter',
         '#icon' => $icon,


### PR DESCRIPTION
## Summary
- fix incorrect property name in FontAwesomeIconFormatter

## Testing
- `php -l src/Plugin/Field/FieldFormatter/FontAwesomeIconFormatter.php` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686768806b7083228eb1e24aac9a6554